### PR TITLE
Prepare v0.4.0 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.27.tgz",
-      "integrity": "sha512-2QMiuVOEye2yKmMwE1V96C9HSShmT0WSm6dv2WjacvePEjQNNJGAerTO5hdYhj5lpdK5MW+FVxmyzDhr4omIdw==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",
+      "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ==",
       "dev": true
     },
     "@types/relateurl": {
@@ -172,9 +172,9 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
+      "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g="
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -403,14 +403,14 @@
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk="
     },
     "babel-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw="
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
@@ -668,9 +668,9 @@
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
-      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE="
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
@@ -703,9 +703,9 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-preset-env": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.1.tgz",
-      "integrity": "sha1-0uymrxee3yfNwwWoSCD2AbRW3Qs="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
+      "integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8="
     },
     "babel-preset-flow": {
       "version": "6.23.0",
@@ -728,24 +728,24 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE="
     },
     "babel-traverse": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE="
     },
     "babel-types": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "babylon": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
-      "integrity": "sha1-IB0l71+JLEG65JSIsI2w3Udun1w="
+      "version": "6.17.3",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+      "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ=="
     },
     "backo2": {
       "version": "1.0.2",
@@ -953,14 +953,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000677",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000677.tgz",
-      "integrity": "sha1-E/Qh1ArhQ0cCEDxJTSxNcW4qj8s="
+      "version": "1.0.30000683",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz",
+      "integrity": "sha1-WLV+0eC7naVOrxRimFFHu+Fmefo="
     },
     "caniuse-lite": {
-      "version": "1.0.30000677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000677.tgz",
-      "integrity": "sha1-QwkCM9SyxxkGV/lUVZg9lNJkuqo="
+      "version": "1.0.30000683",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000683.tgz",
+      "integrity": "sha1-p1c3B88qzJIXymSE0d+8nxOJg2Q="
     },
     "caseless": {
       "version": "0.11.0",
@@ -1060,9 +1060,9 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.2.tgz",
-      "integrity": "sha1-K6n+w7SqQ9eknX5sNWHpIGG2vOw="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
+      "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1237,9 +1237,9 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dependencies": {
         "lru-cache": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
         }
       }
     },
@@ -1496,9 +1496,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz",
-      "integrity": "sha1-GzperObgh7teJXoQCwy/6Bsokfw="
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
+      "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -1737,9 +1737,9 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
     },
     "extract-text-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha1-aTFbiF+Hbb+W04Gfap8cynrr8Vk="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
+      "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw="
     },
     "extract-zip": {
       "version": "1.5.0",
@@ -2592,9 +2592,9 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
     },
     "globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY="
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -2603,16 +2603,9 @@
       "dev": true
     },
     "globule": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-      "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-      "dependencies": {
-        "lodash": {
-          "version": "4.16.6",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-          "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c="
-        }
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3137,12 +3130,6 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
     },
     "js-base64": {
       "version": "2.1.9",
@@ -4395,14 +4382,40 @@
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
     },
     "randomatic": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
+        }
+      }
     },
     "randombytes": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.4.tgz",
-      "integrity": "sha1-lVHfIIQiyPgOtY4jJt0LhA/yLv0="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
+        }
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -4442,9 +4455,9 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
         },
         "lru-cache": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
         }
       }
     },
@@ -4475,9 +4488,9 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
     },
     "readable-stream": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-      "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw=="
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
     },
     "readdirp": {
       "version": "2.1.0",
@@ -4570,9 +4583,9 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-      "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "renderkid": {
       "version": "2.0.1",
@@ -4704,9 +4717,9 @@
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "samsam": {
       "version": "1.2.1",
@@ -4748,14 +4761,7 @@
     "schema-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "dependencies": {
-        "ajv": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
-          "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g="
-        }
-      }
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8="
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -4844,9 +4850,9 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c="
     },
     "shelljs": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true
     },
     "signal-exit": {
@@ -4855,9 +4861,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.2.tgz",
-      "integrity": "sha1-xDqcVw8yuqwRWVBc/u0ZEIhV34k=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
+      "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -4872,9 +4878,9 @@
       }
     },
     "sinon-chai": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.10.0.tgz",
-      "integrity": "sha1-arMAi7jK6ZKedE12ZXS0zzXzS1s="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.11.0.tgz",
+      "integrity": "sha512-3kbzpr2q8N+M4CWkcym349ifwkXorsbw2YyVpEIvB3AKC/ebrLHXj3DySt8epKGA49zJBSgn1OvWHZ+O+aR0dA=="
     },
     "slash": {
       "version": "1.0.0",
@@ -5020,9 +5026,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -5057,9 +5063,9 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
     },
     "string-width": {
       "version": "1.0.2",
@@ -5243,9 +5249,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.2.tgz",
-      "integrity": "sha1-YJtmQMwEJPSjlamt9ow3VWPFScc=",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
+      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
       "dev": true,
       "dependencies": {
         "resolve": {
@@ -5257,9 +5263,9 @@
       }
     },
     "tsutils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.3.0.tgz",
-      "integrity": "sha1-luZh18I2PzGtyJkqxnu+e3/BdeU=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.4.0.tgz",
+      "integrity": "sha1-rUzm26Dlo+2934Ymt8oEB4IYn+o=",
       "dev": true
     },
     "tty-browserify": {
@@ -5456,6 +5462,11 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
       "integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -5534,10 +5545,29 @@
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.0.tgz",
       "integrity": "sha1-oWu1Nbg6aslKeKxevOTzBZ6CdNM="
     },
+    "webpack-manifest-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.1.0.tgz",
+      "integrity": "sha1-a2xxiq3oolN5lXhLRr0umDYFfKo=",
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A="
+        }
+      }
+    },
     "webpack-sources": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-      "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "dependencies": {
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+        }
+      }
     },
     "websocket-driver": {
       "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "url-loader": "^0.5.8",
     "webpack": "^2.6.1",
     "webpack-dev-middleware": "^1.8.4",
-    "webpack-hot-middleware": "^2.13.2"
+    "webpack-hot-middleware": "^2.13.2",
+    "webpack-manifest-plugin": "^1.1.0"
   },
   "devDependencies": {
     "@types/chalk": "^0.4.31",

--- a/src/compilers/web-app/karma/create-config.ts
+++ b/src/compilers/web-app/karma/create-config.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import * as webpack from 'webpack'
-import { findGenesisFile } from '../../../utils/paths'
+import { resolveGenesisPath } from '../../../utils/paths'
 
 export interface KarmaOptions {
   basePath: string,
@@ -9,8 +9,8 @@ export interface KarmaOptions {
 }
 export default function createKarmaConfig (webpackConfig: any, opts: KarmaOptions) {
   const files: Array<string> = []
-  files.push(findGenesisFile('src/compilers/web-app/karma/plugins/mocha.js'))
-  files.push(findGenesisFile('src/compilers/web-app/karma/plugins/test-importer.js'))
+  files.push(resolveGenesisPath('src/compilers/web-app/karma/plugins/mocha.js'))
+  files.push(resolveGenesisPath('src/compilers/web-app/karma/plugins/test-importer.js'))
 
   const karmaConfig = {
     basePath: opts.basePath,

--- a/src/compilers/web-app/karma/plugins/mocha.js
+++ b/src/compilers/web-app/karma/plugins/mocha.js
@@ -34,18 +34,5 @@ chai.use(sinonChai)
 // ------------------------------------
 global.sandbox = sinon.sandbox.create()
 const stub = global.sandbox.stub.bind(global.sandbox)
-global.sandbox.stub = (...args) => {
-  const len = args.length
-  const fake = args[len - 1]
-
-  if (typeof fake === 'function') {
-    console.warn(
-      `sinon.stub(obj, 'method', fn) has been deprecated, ` +
-      `use sinon.stub(obj, 'method').callsFake(fn) instead.`
-    )
-    return stub(...args.slice(0, len - 1)).callsFake(fake)
-  }
-  return stub(...args)
-}
 
 afterEach(() => global.sandbox.restore())

--- a/src/compilers/web-app/webpack/create-config.ts
+++ b/src/compilers/web-app/webpack/create-config.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as webpack from 'webpack'
 import * as HtmlWebpackPlugin from 'html-webpack-plugin'
 import * as ExtractTextPlugin from 'extract-text-webpack-plugin'
-import { findGenesisDependency } from '../../../utils/paths'
+import { resolveGenesisDependency } from '../../../utils/paths'
 
 export default function createWebpackConfig (opts: ICompilerConfig) {
   const inProject = (...paths: Array<string>) => path.resolve(opts.basePath, ...paths)
@@ -52,14 +52,14 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
     test: /\.js$/,
     exclude: /node_modules/,
     use: [{
-      loader: findGenesisDependency('babel-loader'),
+      loader: resolveGenesisDependency('babel-loader'),
       query: {
         cacheDirectory: true,
         plugins: [
-          findGenesisDependency('babel-plugin-transform-class-properties'),
-          findGenesisDependency('babel-plugin-syntax-dynamic-import'),
+          resolveGenesisDependency('babel-plugin-transform-class-properties'),
+          resolveGenesisDependency('babel-plugin-syntax-dynamic-import'),
           [
-            findGenesisDependency('babel-plugin-transform-runtime'),
+            resolveGenesisDependency('babel-plugin-transform-runtime'),
             {
               helpers: true,
               polyfill: false,
@@ -67,15 +67,15 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
             },
           ],
           [
-            findGenesisDependency('babel-plugin-transform-object-rest-spread'),
+            resolveGenesisDependency('babel-plugin-transform-object-rest-spread'),
             {
               usBuiltIns: true,
             },
           ]
         ],
         presets: [
-          findGenesisDependency('babel-preset-react'),
-          [findGenesisDependency('babel-preset-env'), {
+          resolveGenesisDependency('babel-preset-react'),
+          [resolveGenesisDependency('babel-preset-env'), {
             targets: {
               ie9: true,
               uglify: true,
@@ -91,7 +91,7 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
     test: /\.(ts|tsx)$/,
     exclude: /node_modules/,
     use: [{
-      loader: findGenesisDependency('awesome-typescript-loader'),
+      loader: resolveGenesisDependency('awesome-typescript-loader'),
       query: {
         useCache: true,
         configFileName: opts.typescript.configPath,
@@ -104,7 +104,7 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
   // Styles
   // ------------------------------------
   const cssLoader = {
-    loader: findGenesisDependency('css-loader'),
+    loader: resolveGenesisDependency('css-loader'),
     options: {
       sourceMap: opts.sourcemaps,
       minimize: {
@@ -114,7 +114,7 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
           browsers: ['last 2 versions'],
         },
         discardComments: {
-          removeAll : true,
+          removeAll: true,
         },
         discardUnused: false,
         mergeIdents: false,
@@ -134,7 +134,7 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
   config.module.rules.push({
     test: /\.(css)$/,
     loader: extractStyles.extract({
-      fallback: findGenesisDependency('style-loader'),
+      fallback: resolveGenesisDependency('style-loader'),
       use: [
         cssLoader,
       ],
@@ -144,11 +144,11 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
   config.module.rules.push({
     test: /\.(sass|scss)$/,
     loader: extractStyles.extract({
-      fallback: findGenesisDependency('style-loader'),
+      fallback: resolveGenesisDependency('style-loader'),
       use: [
         cssLoader,
         {
-          loader: findGenesisDependency('sass-loader'),
+          loader: resolveGenesisDependency('sass-loader'),
           options: {
             sourceMap: opts.sourcemaps,
             includePaths: [
@@ -174,12 +174,12 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
   // Fonts
   // ------------------------------------
   const FONT_TYPES = new Map([
-    ['woff', 'application/font-woff'],
+    ['woff',  'application/font-woff'],
     ['woff2', 'application/font-woff2'],
-    ['otf', 'font/opentype'],
-    ['ttf', 'application/octet-stream'],
-    ['eot', 'application/vnd.ms-fontobject'],
-    ['svg', 'image/svg+xml'],
+    ['otf',   'font/opentype'],
+    ['ttf',   'application/octet-stream'],
+    ['eot',   'application/vnd.ms-fontobject'],
+    ['svg',   'image/svg+xml'],
   ])
   for (let [extension, mimetype] of FONT_TYPES) {
     config.module.rules.push({
@@ -204,7 +204,7 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
     },
   }
   // HtmlWebpackPlugin doesn't work if `template` is undefined or null, so
-  // we have to explicitly delete the key when it's undefined.
+  // we have to explicitly delete the key when it's not defined.
   if (!htmlWebpackPluginOpts.template) {
     delete htmlWebpackPluginOpts.template
   }

--- a/src/compilers/web-app/webpack/create-config.ts
+++ b/src/compilers/web-app/webpack/create-config.ts
@@ -2,6 +2,8 @@ import { ICompilerConfig } from '../../../lib/compiler'
 import * as path from 'path'
 import * as webpack from 'webpack'
 import * as HtmlWebpackPlugin from 'html-webpack-plugin'
+// TODO: make tsified
+const WebpackManifestPlugin = require('webpack-manifest-plugin')
 import * as ExtractTextPlugin from 'extract-text-webpack-plugin'
 import { resolveGenesisDependency } from '../../../utils/paths'
 
@@ -37,6 +39,9 @@ export default function createWebpackConfig (opts: ICompilerConfig) {
       rules: [] as Array<any>,
     },
     plugins: [
+      new WebpackManifestPlugin({
+        fileName: 'asset-manifest.json',
+      }),
       new webpack.DefinePlugin(Object.assign({
         'process.env': { NODE_ENV: JSON.stringify(opts.env) },
         __DEV__,

--- a/src/compilers/web-app/webpack/create-dev-middleware.ts
+++ b/src/compilers/web-app/webpack/create-dev-middleware.ts
@@ -1,11 +1,11 @@
 import * as webpack from 'webpack'
 import * as webpackDevMiddleware from 'webpack-dev-middleware'
 import * as webpackHotMiddleware from 'webpack-hot-middleware'
-import { findGenesisDependency } from '../../../utils/paths'
+import { resolveGenesisDependency } from '../../../utils/paths'
 
 export type Middleware = any
 export type CreateDevMiddlewareOpts = {
-  protocol: string,
+  protocol: 'http' | 'https',
   host: string,
   port: number,
   contentBase: string,
@@ -15,8 +15,8 @@ export type CreateDevMiddlewareOpts = {
 const createDevMiddleware = (webpackConfig: any, opts: CreateDevMiddlewareOpts): Array<Middleware> => {
   webpackConfig.output.publicPath = `${opts.protocol}://${opts.host}:${opts.port}/`
   webpackConfig.entry.main.unshift(
-    findGenesisDependency('react-error-overlay'),
-    findGenesisDependency('webpack-hot-middleware/client.js') +
+    resolveGenesisDependency('react-error-overlay'),
+    resolveGenesisDependency('webpack-hot-middleware/client.js') +
     `?path=${webpackConfig.output.publicPath}__webpack_hmr`,
   )
   webpackConfig.plugins.push(

--- a/src/compilers/web-app/webpack/create-dev-server.ts
+++ b/src/compilers/web-app/webpack/create-dev-server.ts
@@ -32,7 +32,7 @@ class DevServer {
     this._server.start = () => new Promise(resolve => {
       this._server.listen(opts.port, opts.host, () => {
         logger.info('Starting compiler...')
-        logger.info(chalk.bold(`Development running at ${opts.protocol}://${opts.host}:${opts.port}.`))
+        logger.info(chalk.bold(`Development running at ${opts.protocol}://${opts.host}:${opts.port}`))
         resolve()
       })
     })

--- a/src/compilers/web-app/webpack/create-dev-server.ts
+++ b/src/compilers/web-app/webpack/create-dev-server.ts
@@ -7,23 +7,23 @@ import createDevMiddleware, { CreateDevMiddlewareOpts } from './create-dev-middl
 import * as logger from '../../../utils/logger'
 
 export interface DevServerOpts {
-  protocol: string,
+  protocol: 'http' | 'https',
   host: string,
   port: number,
 }
 class DevServer {
-  _server: any
+  private _server: any
 
-  constructor (config: ICompilerConfig, overrides?: Partial<DevServerOpts>) {
-    const defaults: CreateDevMiddlewareOpts = {
+  constructor (config: ICompilerConfig, options?: Partial<DevServerOpts>) {
+    const opts: CreateDevMiddlewareOpts = {
       protocol: 'http',
       host: 'localhost',
       port: 3000,
       contentBase: path.resolve(config.basePath, config.srcDir),
       onCompilerFinish: this._onCompilerFinish.bind(this),
       onCompilerStart: this._onCompilerStart.bind(this),
+      ...options,
     }
-    const opts: CreateDevMiddlewareOpts = Object.assign(defaults, overrides)
 
     this._server = express()
     this._server.use(require('connect-history-api-fallback')())
@@ -31,8 +31,8 @@ class DevServer {
     this._server.use(express.static(path.resolve(config.basePath, 'public')))
     this._server.start = () => new Promise(resolve => {
       this._server.listen(opts.port, opts.host, () => {
-        logger.info(chalk.bold(`Development server started on http://${opts.host}:${opts.port}.`))
         logger.info('Starting compiler...')
+        logger.info(chalk.bold(`Development running at ${opts.protocol}://${opts.host}:${opts.port}.`))
         resolve()
       })
     })
@@ -60,7 +60,6 @@ class DevServer {
 
   async start () {
     await this._server.start()
-    return
   }
 
   async stop () {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,9 +1,7 @@
 import * as path from 'path'
 
-export const findGenesisFile = (target: string): string =>
+export const resolveGenesisPath = (target: string): string =>
   path.resolve(__dirname, '../../' + target)
 
-export const findGenesisDependency = (target: string): string | never => {
-  const [filepath, query = ''] = target.split('?')
-  return require.resolve(filepath) + (query ? '?query' : '')
-}
+export const resolveGenesisDependency = (target: string): string =>
+  require.resolve(target)


### PR DESCRIPTION
I'd like to make a minor release with these changes.  The `npm link` method breaks every time I install or uninstall any other package.  I have to re-create the link, rm -rf node_modules, install again, then re-link.  Probably an NPM v5 bug, I hope.