### PR TITLE
fix(create-dev-server): respect opts.port

### DIFF
--- a/src/webpack/create-dev-server.js
+++ b/src/webpack/create-dev-server.js
@@ -58,7 +58,7 @@ const createDevServer = (config, opts) => {
   opts = Object.assign({}, {
     protocol: 'http',
     host: 'localhost',
-    port: 3000,
+    port: opts.port || 3000,
     onChange: (file) => {
       printInteractiveMode()
       log.info(`Detected file change: ${chalk.bold(file)}`)


### PR DESCRIPTION
Currently, the port is hard coded to 3000.  Per the docs, passing a port should start the server on the specified port.  There is also a console log following server start that logs `opts.port` as the port.

This PR uses `opts.port` when starting the server and defaults to 3000 if not provided.